### PR TITLE
Add support for weave in lint script.

### DIFF
--- a/lint
+++ b/lint
@@ -11,7 +11,25 @@
 # To use this script automatically, run:
 #   ln -s ../../bin/lint .git/hooks/pre-commit
 
-set -eu
+set -e
+
+IGNORE_LINT_COMMENT=
+IGNORE_TEST_PACKAGES=
+while true; do
+	case "$1" in
+		-nocomment)
+		IGNORE_LINT_COMMENT=1
+		shift 1
+		;;
+		-notestpackage)
+		IGNORE_TEST_PACKAGES=1
+		shift 1
+		;;
+		*)
+		break
+	esac
+done
+
 
 function spell_check {
 	filename="$1"
@@ -64,7 +82,11 @@ function lint_go {
 	# don't have it installed.
 	if type golint >/dev/null 2>&1; then
 		# golint doesn't set an exit code it seems
-		lintoutput=$(golint "${filename}")
+		if [ "$IGNORE_LINT_COMMENT" = "1" ]; then
+			lintoutput=$(golint "${filename}" | grep -vE 'comment|dot imports')
+		else
+			lintoutput=$(golint "${filename}")
+		fi
 		if [ "$lintoutput" != "" ]; then
 			lint_result=1
 			echo "$lintoutput"
@@ -105,8 +127,10 @@ function lint {
 		;;
 	esac
 
-	if [[ $filename == *"_test.go" ]]; then
-		test_mismatch "${filename}" || lint_result=1
+	if [ -z "$IGNORE_TEST_PACKAGES" ]; then
+		if [[ "$filename" == *"_test.go" ]]; then
+			test_mismatch "${filename}" || lint_result=1
+		fi
 	fi
 
 	spell_check "${filename}" || lint_result=1

--- a/lint
+++ b/lint
@@ -82,12 +82,12 @@ function lint_go {
 	# don't have it installed.
 	if type golint >/dev/null 2>&1; then
 		# golint doesn't set an exit code it seems
-		if [ "$IGNORE_LINT_COMMENT" = "1" ]; then
-			lintoutput=$(golint "${filename}" | grep -vE 'comment|dot imports')
-		else
+		if [ -z "$IGNORE_LINT_COMMENT"  ]; then
 			lintoutput=$(golint "${filename}")
+		else
+			lintoutput=$(golint "${filename}" | grep -vE 'comment|dot imports')
 		fi
-		if [ "$lintoutput" != "" ]; then
+		if [ -n "$lintoutput" ]; then
 			lint_result=1
 			echo "$lintoutput"
 		fi


### PR DESCRIPTION
The weave repo has some slight modifications to the lint script:
- they ignore lint errors about comments
- they aren't strict about test packages and file names

This changes adds ```-nocomment``` and ```-notestpackage``` arguments to the lint script, so weave can start to share the same script.